### PR TITLE
Added case for value_not_found api error

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -2,6 +2,7 @@
 
 use GoCardless\Pro\Exceptions\InvalidStateException;
 use GoCardless\Pro\Exceptions\ResourceNotFoundException;
+use GoCardless\Pro\Exceptions\VersionNotFoundException;
 use GoCardless\Pro\Exceptions\ValidationException;
 use GoCardless\Pro\Models\Creditor;
 use GoCardless\Pro\Models\CreditorBankAccount;
@@ -499,6 +500,11 @@ class Api
             case 'resource_not_found' :
                 throw new ResourceNotFoundException(
                     sprintf('Resource not found at %s', $ex->getRequest()->getResource()),
+                    $ex->getCode()
+                );
+            case 'version_not_found' :
+                throw new VersionNotFoundException(
+                    'Version not found',
                     $ex->getCode()
                 );
         }

--- a/src/Api.php
+++ b/src/Api.php
@@ -454,6 +454,7 @@ class Api
      * @throws InvalidStateException
      * @throws ResourceNotFoundException
      * @throws ValidationException
+     * @throws VersionNotFoundException
      */
     private function handleBadResponseException(BadResponseException $ex)
     {
@@ -493,6 +494,7 @@ class Api
      * @param BadResponseException $ex
      * @param array $response
      * @throws ResourceNotFoundException
+     * @throws VersionNotFoundException
      */
     private function handleInvalidApiUsage(BadResponseException $ex, $response)
     {

--- a/src/Exceptions/VersionNotFoundException.php
+++ b/src/Exceptions/VersionNotFoundException.php
@@ -1,0 +1,7 @@
+<?php namespace GoCardless\Pro\Exceptions;
+
+use Exception;
+
+class VersionNotFoundException extends Exception
+{
+}

--- a/tests/Exceptions/VersionNotFoundExceptionTest.php
+++ b/tests/Exceptions/VersionNotFoundExceptionTest.php
@@ -1,0 +1,15 @@
+<?php namespace GoCardless\Pro\Tests\Exceptions;
+
+use GoCardless\Pro\Exceptions\VersionNotFoundException;
+
+class VersionNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    function it_can_be_created()
+    {
+        $ex = new VersionNotFoundException('A simple message', 400);
+
+        $this->assertEquals('A simple message', $ex->getMessage());
+        $this->assertEquals(400, $ex->getCode());
+    }
+}


### PR DESCRIPTION
Added an extra case in Api::handleInvalidApiUsage which catches the
version_not_found error and throws a VersionNotFoundException
