### PR TITLE
Authentication update for API version 2015-04-29

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -4,7 +4,6 @@
  * This configuration is only needed for running tests.
  */
 return [
-    'version'  => '2014-11-03',
-    'username' => '',
-    'password' => '',
+    'version'       => '2015-04-29',
+    'accessToken'   => '',
 ];

--- a/examples/hello-money.php
+++ b/examples/hello-money.php
@@ -23,7 +23,7 @@ use GoCardless\Pro\Models\Payment;
  * @link https://manage-sandbox.gocardless.com/organisation
  * @link https://developer.gocardless.com/pro/#overview-backwards-compatibility
  */
-$api = new Api(new Client, 'API_ID', 'API_KEY', '2014-11-03');
+$api = new Api(new Client, 'ACCESS_TOKEN', '2015-04-29');
 
 /** On with the show */
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -36,12 +36,7 @@ class Api
     /**
      * @var string
      */
-    private $username;
-
-    /**
-     * @var string
-     */
-    private $password;
+    private $accessToken;
 
     /**
      * @var string
@@ -53,11 +48,10 @@ class Api
      */
     private $environment;
 
-    public function __construct(Client $client, $username, $password, $version, $environment = 'staging')
+    public function __construct(Client $client, $accessToken, $version, $environment = 'staging')
     {
         $this->client      = $client;
-        $this->username    = $username;
-        $this->password    = $password;
+        $this->accessToken = $accessToken;
         $this->version     = $version;
         $this->environment = $environment === 'production' ? 'production' : 'staging';
     }
@@ -382,8 +376,7 @@ class Api
 
             $response = $this->client->post($this->url($endpoint, $path), [
                 'headers' => $headers,
-                'json'    => $payload,
-                'auth'    => [$this->username, $this->password]
+                'json'    => $payload
             ]);
         } catch (BadResponseException $ex) {
             $this->handleBadResponseException($ex);
@@ -413,8 +406,7 @@ class Api
 
         try {
             $response = $this->client->get($this->url($endpoint, $path), [
-                'headers' => $headers,
-                'auth'    => [$this->username, $this->password]
+                'headers' => $headers
             ]);
         } catch (BadResponseException $ex) {
             $this->handleBadResponseException($ex);
@@ -491,8 +483,7 @@ class Api
         try {
             $response = $this->client->get($this->url($endpoint, $path), [
                 'headers' => $this->headers(),
-                'query'   => $params,
-                'auth'    => [$this->username, $this->password]
+                'query'   => $params
             ])->json();
         } catch (BadResponseException $ex) {
             $this->handleBadResponseException($ex);
@@ -542,8 +533,7 @@ class Api
 
             $response = $this->client->$method($this->url($endpoint, $path), [
                 'headers' => $this->headers(),
-                'json'    => $payload,
-                'auth'    => [$this->username, $this->password]
+                'json'    => $payload
             ])->json();
         } catch (BadResponseException $ex) {
             $this->handleBadResponseException($ex);
@@ -580,7 +570,8 @@ class Api
     {
         return [
             'GoCardless-Version' => $this->version,
-            'Content-Type'       => 'application/json'
+            'Content-Type'       => 'application/json',
+            'Authorization'      => sprintf('Bearer %s', $this->accessToken)
         ];
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -22,7 +22,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $config = require __DIR__ . '/../config.php';
 
-        $this->api = new Api(new Client, $config['username'], $config['password'], $config['version']);
+        $this->api = new Api(new Client, $config['accessToken'], $config['version']);
     }
 
     /** @test */
@@ -30,8 +30,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('GoCardless\Pro\Api', $this->api);
         $this->assertAttributeInstanceOf('GuzzleHttp\Client', 'client', $this->api);
-        $this->assertAttributeNotEmpty('username', $this->api);
-        $this->assertAttributeNotEmpty('password', $this->api);
+        $this->assertAttributeNotEmpty('accessToken', $this->api);
         $this->assertAttributeEquals('staging', 'environment', $this->api);
     }
 
@@ -471,7 +470,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $config = require __DIR__ . '/../config.php';
 
-        $api = new Api(new Client, $config['username'], $config['password'], '1970-01-01');
+        $api = new Api(new Client, $config['accessToken'], '1970-01-01');
 
         $api->listCustomers();
     }


### PR DESCRIPTION
This PR updates the library to use the new AccessToken based authentication for GoCardless Pro API version 2015-04-29. This is _not_ backwards compatible with the old API versions (which will be discontinued anyway).

Part of issue #9
