### PR TITLE
Removed return statement as they prevent an exception from being thrown

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -614,10 +614,10 @@ class Api
                 );
 
             case 'validation_failed' :
-                return $this->handleValidationFailedErrors($response);
+                $this->handleValidationFailedErrors($response);
 
             case 'invalid_api_usage' :
-                return $this->handleInvalidApiUsage($ex, $response);
+                $this->handleInvalidApiUsage($ex, $response);
         }
 
         throw $ex;


### PR DESCRIPTION
If the reason doesn't match in `handleInvalidApiUsage`, no exceotion is
ever thrown. Removing the return statement will let it fall through to
`throw $ex` in `handleBadResponseException`

Issue #21 
